### PR TITLE
Disable reload sound if its deactivated for players

### DIFF
--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -9,6 +9,8 @@ if (hasInterface) then {
 	GVAR(reloadBuffer) = 0;
 
 	[{
+		if (!GVAR(enablePlayers)) exitWith {};
+		
 		if (inputAction "reloadMagazine" > 0) then {
 			// Prevent spam if holding the key down
 			if (!GVAR(reloadAllow) || GVAR(reloadBuffer) > CBA_missionTime) exitWith {};
@@ -33,16 +35,16 @@ if (hasInterface) then {
 		} else {
 			GVAR(reloadAllow) = true;
 		};
-	},0] call CBA_fnc_addPerFrameHandler;
+	}, 0] call CBA_fnc_addPerFrameHandler;
 
 	// Callout keybind
-	[LSTRING(UnitVoiceOvers),"UVO_callout",LSTRING(Keybind_Callout),{
+	[LSTRING(UnitVoiceOvers), "UVO_callout", LSTRING(Keybind_Callout), {
 		[call CBA_fnc_currentUnit] call FUNC(calloutDir);
 		false
-	},{false},[20,[false,false,false]],false] call CBA_fnc_addKeybind;
+	}, {false}, [20, [false, false, false]], false] call CBA_fnc_addKeybind;
 };
 
 // Suppression feature
 GVAR(projectiles) = [];
 GVAR(projectileIndex) = 0;
-GVAR(suppressionEFID) = addMissionEventHandler ["EachFrame",{call FUNC(suppressionLoop)}];
+GVAR(suppressionEFID) = addMissionEventHandler ["EachFrame", {call FUNC(suppressionLoop)}];


### PR DESCRIPTION
ATM we dont want that the player says things... but the player screams RELOAD ^^

In the legacy version it was also fixed later: https://github.com/ygokmen/unit-voiceovers/blob/213854b6fc57c0c44c99780f0b409df8cb8dfbe6/addons/UVO/functions/eventhandler/fn_firedEH.sqf#L18