### PR TITLE
Fixed drones playing death sound on death

### DIFF
--- a/addons/main/functions/fnc_initPost.sqf
+++ b/addons/main/functions/fnc_initPost.sqf
@@ -3,6 +3,7 @@
 params ["_unit"];
 
 if (isNull _unit || !local _unit) exitWith {};
+if (getText (configOf _unit >> "simulation") == "UAVPilot") exitWith {};
 
 private _voice = switch true do {
 	case (_unit isKindOf "SoldierEB") : {"EAST"};


### PR DESCRIPTION
- fnc_initPost.sqf now checks if the unit is a UAV pilot before adding UVO info to it.