### PR TITLE
Western Sahara Fix

### DIFF
--- a/addons/main/functions/fnc_initPost.sqf
+++ b/addons/main/functions/fnc_initPost.sqf
@@ -3,6 +3,7 @@
 params ["_unit"];
 
 if (isNull _unit || !local _unit) exitWith {};
+if ("InvisibleUniform_lxws" in typeOf _unit) exitWith {};
 
 private _voice = switch true do {
 	case (_unit isKindOf "SoldierEB") : {"EAST"};


### PR DESCRIPTION
- Added a check to ensure that the invisible unit spawned on the Western Sahara open top APC does not have UVO active as the unit is an agent used for targeting.

The exact fix was done by https://github.com/OverlordZorn for our own version of the mod.